### PR TITLE
Fixes  [Bug]: This database engine does not support JSON operations. #9 

### DIFF
--- a/src/Database/LibSQLConnection.php
+++ b/src/Database/LibSQLConnection.php
@@ -36,6 +36,13 @@ class LibSQLConnection extends Connection
         return $resultArray;
     }
 
+    protected function getDefaultQueryGrammar()
+    {
+        ($grammar = new LibSQLQueryGrammar())->setConnection($this);
+
+        return $grammar;
+    }
+
     /**
      * Get the default schema grammar instance.
      *


### PR DESCRIPTION
This PR fixes https://github.com/tursodatabase/turso-driver-laravel/issues/9

I've added default grammar method, so it's resolved correctly now.

I can't add test, since tests structure was added in https://github.com/tursodatabase/turso-driver-laravel/pull/5.

Test which clearly tests for problem can be found here - https://github.com/tursodatabase/turso-driver-laravel/commit/92b3a1c630db8ebe1714bfd9e3f136eb026e711e