### PR TITLE
Adding tests structure with some basic tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9",
+        "orchestra/testbench": "^9.1",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3",
@@ -36,11 +37,40 @@
     "autoload": {
         "psr-4": {
             "Turso\\Driver\\Laravel\\": "src/",
+            "Turso\\Driver\\Laravel\\Tests\\": "tests/",
             "Turso\\Driver\\Laravel\\Database\\Factories\\": "database/factories/"
         }
     },
     "scripts": {
-        "format": "vendor/bin/pint"
+        "format": "vendor/bin/pint",
+        "post-autoload-dump": [
+            "@clear",
+            "@prepare"
+        ],
+        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
+        "prepare": "@php vendor/bin/testbench package:discover --ansi",
+        "build": "@php vendor/bin/testbench workbench:build --ansi",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "@build",
+            "@php vendor/bin/testbench serve"
+        ],
+        "lint": [
+            "@php vendor/bin/pint",
+            "@php vendor/bin/phpstan analyse"
+        ],
+        "phpstan-baseline": [
+            "@php vendor/bin/phpstan -b"
+        ],
+        "test": [
+            "@php vendor/bin/phpunit"
+        ],
+        "test-feature": [
+            "@php vendor/bin/phpunit --testsuite=Feature"
+        ],
+        "test-unit": [
+            "@php vendor/bin/phpunit --testsuite=Unit"
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,8 +5,6 @@ parameters:
     level: 5
     paths:
         - src
-        - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,8 +16,11 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="VendorName Test Suite">
-            <directory>tests</directory>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
     <coverage>

--- a/tests/Feature/ConnectionsSetupTest.php
+++ b/tests/Feature/ConnectionsSetupTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Turso\Driver\Laravel\Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Turso\Driver\Laravel\Database\LibSQLConnection;
+use Turso\Driver\Laravel\Database\LibSQLDatabase;
+
+
+class ConnectionsSetupTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        if (File::exists('tests/_files/test.db')) {
+            File::delete('tests/_files/test.db');
+        }
+        parent::tearDown();
+    }
+
+    public function testConnectionInMemory(): void
+    {
+        config()->set('database.default', 'libsql');
+        config()->set('database.connections.libsql', [
+            'driver' => 'libsql',
+            'url' => 'file::memory:', // Taken from README docs
+            'authToken' => '', // This should be defied even with memory, which is not right
+            'syncUrl' => '', // This should be defied even with memory, which is not right
+            'encryptionKey' => '', // This should be defied even with memory, which is not right
+            'remoteOnly' => false, // This should be defied even with memory, which is not right
+            'prefix' => '',
+            'database' => null, // doesn't matter actually, since we use sqlite
+        ]);
+        // Get the default connection
+        $connection = DB::connection('libsql');
+
+        // Assert that the connection is an instance of LibSQLConnection
+        $this->assertInstanceOf(LibSQLConnection::class, $connection);
+
+        // Get the PDO instance
+        $pdo = $connection->getPdo();
+
+        $this->assertInstanceOf(LibSQLDatabase::class, $pdo);
+        $this->assertEquals('local', $pdo->getDb()->mode);
+        $this->assertEquals('memory', $pdo->getConnectionMode());
+        // we get "local" since our path is file:/turso-driver-laravel/vendor/orchestra/testbench-core/laravel/database/:memory:
+        // which is also wrong since we want just to use memory according to README.md
+        $result = $connection->select('PRAGMA database_list');
+        $this->assertNotEmpty($result);
+        $result = $pdo->query('SELECT sqlite_version()');
+        $this->assertNotEmpty($result, 'Failed to query SQLite version');
+    }
+
+    public function testConnectionLocalFile(): void
+    {
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.local_file', [
+            'driver' => 'libsql',
+            'url' => 'file:/tests/_files/test.db',
+            'authToken' => '',
+            'syncUrl' => '',
+            'syncInterval' => 5,
+            'readYourWrites' => true,
+            'encryptionKey' => '',
+            'remoteOnly' => false,
+            'prefix' => '',
+            'database' => null, // doesn't matter actually, since we use sqlite
+        ]);
+
+        $connection = DB::connection('local_file');
+
+        // Assert that the connection is an instance of LibSQLConnection
+        $this->assertInstanceOf(LibSQLConnection::class, $connection);
+
+        // Get the PDO instance
+        $pdo = $connection->getPdo();
+
+        $this->assertInstanceOf(LibSQLDatabase::class, $pdo);
+        $this->assertEquals('local', $pdo->getDb()->mode);
+        $this->assertEquals('local', $pdo->getConnectionMode());
+        $result = $connection->select('PRAGMA database_list');
+        $this->assertNotEmpty($result);
+        $result = $pdo->query('SELECT sqlite_version()');
+        $this->assertNotEmpty($result, 'Failed to query SQLite version');
+
+        $this->assertTrue(File::exists('tests/_files/test.db'), 'No file created or wrong path');
+    }
+}

--- a/tests/Feature/CreateRecordsTest.php
+++ b/tests/Feature/CreateRecordsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Turso\Driver\Laravel\Tests\Feature;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRecordsTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.local_file', [
+            'driver' => 'libsql',
+            'url' => 'file:/tests/_files/test.db',
+            'authToken' => '',
+            'syncUrl' => '',
+            'syncInterval' => 5,
+            'readYourWrites' => true,
+            'encryptionKey' => '',
+            'remoteOnly' => false,
+            'prefix' => '',
+            'database' => null, // doesn't matter actually, since we use sqlite
+        ]);
+        Schema::connection('local_file')
+            ->dropIfExists('test');
+        Schema::connection('local_file')
+            ->create('test', function (\Illuminate\Database\Schema\Blueprint $table) {
+                $table->id();
+                $table->text('text');
+                $table->json('json');
+                $table->string('string');
+
+                $table->timestamps();
+            });
+    }
+
+    public function tearDown(): void
+    {
+        if (File::exists('tests/_files/test.db')) {
+            File::delete('tests/_files/test.db');
+        }
+        parent::tearDown();
+    }
+
+    public function testCreateViaDB(): void
+    {
+        DB::connection('local_file')
+            ->table('test')
+            ->delete();
+
+        $id = DB::connection('local_file')
+            ->table('test')
+            ->insertGetId([
+                'text' => 'text',
+                'json' => json_encode(['test' => 'test']),
+                'string' => 'string',
+            ]);
+        $this->assertEquals(1, $id);
+        // not working, since insertGetId returns false instead of 1
+
+        DB::connection('local_file')
+            ->table('test')
+            ->insert([
+                'text' => 'text2',
+                'json' => json_encode(['test2' => 'test']),
+                'string' => 'string2',
+            ]);
+
+
+        $data = DB::connection('local_file')
+            ->table('test')
+            ->select()
+            ->get();
+        $this->assertEquals(2, count($data));
+
+        $this->assertEquals('text2', $data[1]['text']);
+    }
+
+    public function testCreateViaEloquent(): void
+    {
+        $modelClass = new class extends Model
+        {
+            protected $connection = 'local_file';
+
+            protected $table = 'test';
+
+            protected $fillable = ['text'];
+
+            public function casts()
+            {
+                return [
+                    'json' => 'array',
+                ];
+            }
+        };
+
+        $model = new $modelClass(['text' => 'test']);
+        $model->json = ['test' => 'test'];
+        $model->string = 'string';
+
+        $model->save();
+        $this->assertEquals(1, $model->id); // not working since insertGetId is not working
+        $model->refresh();
+
+        $this->assertNotEmpty($model->created_at);
+
+        $data = DB::connection('local_file')
+            ->table('test')
+            ->select()
+            ->get();
+        $this->assertEquals(1, count($data));
+
+        // testing that grammar is correct and json is working
+        $result = $model::query()
+            ->where(function ($query) {
+                $query->where('json->test', 'test');
+            })
+            ->first();
+        $this->assertEquals(1, $result->id);
+    }
+}

--- a/tests/Feature/CreateRecordsTest.php
+++ b/tests/Feature/CreateRecordsTest.php
@@ -80,6 +80,39 @@ class CreateRecordsTest extends TestCase
         $this->assertEquals('text2', $data[1]['text']);
     }
 
+    public function testWithBLOBType(): void
+    {
+        $modelClass = new class extends Model
+        {
+            protected $connection = 'local_file';
+
+            protected $table = 'test';
+
+            protected $fillable = ['text'];
+
+            public function casts()
+            {
+                return [
+                    'json' => 'array',
+                ];
+            }
+        };
+
+        $model = new $modelClass(['text' => str_repeat('{SOME TEST CONTENT HERE!}', 2)]);
+        $model->json = ['test' => 'test'];
+        $model->string = 'string';
+
+        $model->save();
+
+        $data = DB::connection('local_file')
+            ->table('test')
+            ->select()
+            ->get()
+            ->first();
+
+        $this->assertEquals(str_repeat('{SOME TEST CONTENT HERE!}', 2), $data['text']);
+    }
+
     public function testCreateViaEloquent(): void
     {
         $modelClass = new class extends Model

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Turso\Driver\Laravel\Tests\Feature;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+    public function getPackageProviders($app)
+    {
+        return [
+            \Turso\Driver\Laravel\LibSQLDriverServiceProvider::class,
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        // Perform any environment setup
+    }
+}

--- a/tests/Unit/LibSQLConnectionTest.php
+++ b/tests/Unit/LibSQLConnectionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Turso\Driver\Laravel\Database\LibSQLConnection;
+use Turso\Driver\Laravel\Database\LibSQLDatabase;
+
+class LibSQLConnectionTest extends TestCase
+{
+    private LibSQLConnection $connection;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $mockDatabase = $this->createMock(LibSQLDatabase::class);
+        $this->connection = new LibSQLConnection($mockDatabase);
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->connection);
+        parent::tearDown();
+    }
+
+    #[DataProvider(methodName: 'escapeStringProvider')]
+    public function testEscapeString($string, $expected): void
+    {
+        $result = $this->connection->escapeString($string);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function escapeStringProvider(): array
+    {
+        return [
+            'null value' => [null, 'NULL'],
+            'empty string' => ['', ''],
+            'simple string' => ['hello', 'hello'],
+            'string with single quote' => ["O'Reilly", "O\\'Reilly"],
+            'string with double quote' => ['Say "Hello"', 'Say \\"Hello\\"'],
+            'string with backslash' => ['C:\\path\\to\\file', 'C:\\\\path\\\\to\\\\file'],
+            'string with newline' => ["Line1\nLine2", "Line1\\nLine2"],
+            'string with carriage return' => ["Line1\rLine2", "Line1\\rLine2"],
+            'string with null byte' => ["Null\x00Byte", "Null\\0Byte"],
+            'string with substitute character' => ["Sub\x1aChar", "Sub\\ZChar"],
+            'complex string' => ["It's a \"complex\" string\nWith multiple 'special' chars\x00\r\n", "It\\'s a \\\"complex\\\" string\\nWith multiple \\'special\\' chars\\0\\r\\n"],
+        ];
+    }
+
+    #[DataProvider(methodName: 'quoteProvider')]
+    public function testQuote($string, $expected): void
+    {
+        $result = $this->connection->quote($string);
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function quoteProvider(): array
+    {
+        return [
+            'empty string' => ['', '\'\''],
+            'simple string' => ['hello', '\'hello\''],
+            'string with single quote' => ["O'Reilly", "'O\\'Reilly'"],
+            'string with double quote' => ['Say "Hello"', "'Say \\\"Hello\\\"'"],
+            'string with backslash' => ['C:\\path\\to\\file', "'C:\\\\path\\\\to\\\\file'"],
+            'string with newline' => ["Line1\nLine2", "'Line1\\nLine2'"],
+            'string with carriage return' => ["Line1\rLine2", "'Line1\\rLine2'"],
+            'string with null byte' => ["Null\x00Byte", "'Null\\0Byte'"],
+            'string with substitute character' => ["Sub\x1aChar", "'Sub\\ZChar'"],
+            'multi-byte characters' => ['こんにちは', "'こんにちは'"],
+            'very long string' => [str_repeat('a', 1000000), "'" . str_repeat('a', 1000000) . "'"],
+        ];
+    }
+
+    #[DataProvider(methodName: 'sqlInjectionEncodingProvider')]
+    public function testSQLInjectionViaEncoding($input, $expected)
+    {
+        $result = $this->connection->quote($input);
+        $this->assertEquals($expected, $result);
+
+        $this->assertFalse(strpos($result, "';") !== false, "Potential SQL injection point found");
+    }
+
+    public static function sqlInjectionEncodingProvider(): array
+    {
+        return [
+            'Single Quote' => [
+                "OR '1'='1;",
+                "'OR \\'1\\'=\\'1;'"
+            ],
+            'Double Quote' => [
+                'OR "1"="1;',
+                "'OR \\\"1\\\"=\\\"1;'"
+            ],
+            'Latin1 to UTF-8 Single Quote' => [
+                utf8_encode("¿'").";",
+                "'Â¿\\';'"
+            ],
+            'Unicode Code Points' => [
+                "' OR 1=1--;",
+                "'\\' OR 1=1--;'"
+            ],
+            'URL Encoded Quotes' => [
+                "' %27 OR '1'='1;",
+                "'\\' %27 OR \\'1\\'=\\'1;'"
+            ],
+            'Multi-byte Character Before Quote' => [
+                '中文\'OR\'1\'=\'1;',
+                "'中文\\'OR\\'1\\'=\\'1;'"
+            ],
+            'Null Byte Injection' => [
+                "admin\0' OR '1'='1;",
+                "'admin\\0\\' OR \\'1\\'=\\'1;'"
+            ],
+            'Unicode Normalization' => [
+                "¼' OR '1'='1;",
+                "'¼\\' OR \\'1\\'=\\'1;'"
+            ],
+            'Emoji with Single Quote' => [
+                "🔥' OR '1'='1;",
+                "'🔥\\' OR \\'1\\'=\\'1;'"
+            ],
+        ];
+    }
+}

--- a/tests/_files/.gitignore
+++ b/tests/_files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Added `orchestra/testbench` to test package.
Added composer commands:
```
"post-autoload-dump": [
            "@clear",
            "@prepare"
        ],
        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
        "prepare": "@php vendor/bin/testbench package:discover --ansi",
        "build": "@php vendor/bin/testbench workbench:build --ansi",
        "serve": [
            "Composer\\Config::disableProcessTimeout",
            "@build",
            "@php vendor/bin/testbench serve"
        ],
        "lint": [
            "@php vendor/bin/pint",
            "@php vendor/bin/phpstan analyse"
        ],
        "phpstan-baseline": [
            "@php vendor/bin/phpstan -b"
        ],
        "test": [
            "@php vendor/bin/phpunit"
        ],
        "test-feature": [
            "@php vendor/bin/phpunit --testsuite=Feature"
        ],
        "test-unit": [
            "@php vendor/bin/phpunit --testsuite=Unit"
        ]
```

Added some basic tests:
 - \Turso\Driver\Laravel\Tests\Feature\ConnectionsSetupTest - tests how connection configuration setup is working
 - \Turso\Driver\Laravel\Tests\Feature\CreateRecordsTest - tests new record creation
 
To run single test you can use `./vendor/bin/phpunit --filter=CreateRecordsTest::testCreateViaEloquent`

I've decided not to put errors into phpstan baseline, si8nce some of them should be fixed.